### PR TITLE
update script to write directly to S3

### DIFF
--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -1,6 +1,10 @@
+import sys
 import firebase_admin
-from firebase_admin import firestore
+import re
+import boto3
 import json
+from datetime import datetime
+from firebase_admin import firestore
 from os.path import exists
 
 def get_credentials():
@@ -9,25 +13,56 @@ def get_credentials():
         cert_path = input('invalid file path. Please enter path to Floop cert file: ')
     return cert_path
 
+
+def connect_s3():
+    key_id = sys.argv[2] if len(sys.argv) > 2 else input("Enter your AWS access key id: ")
+    # we know what a secret access key ID should look like but not what the key itself should look like
+    # docs https://docs.aws.amazon.com/STS/latest/APIReference/API_Credentials.html
+    while not re.match("\w{16,128}", key_id):
+        print("Key in incorrect format, please try again")
+        key_id = input("re-enter your key: ")
+    secret_key = sys.argv[3] if len(sys.argv) > 3 else input("enter your AWS secret access key: ")
+    return boto3.Session(aws_access_key_id=key_id, aws_secret_access_key=secret_key)
+
+
+def upload_s3(json):
+    s3_session = connect_s3().resource('s3')
+    time = datetime.now().strftime("%m-%d-%Y-%H-%M-%S")
+    # add file to bucket with current date and time for posterity
+    s3_session_object = s3_session.Object('floop-dataset', 'floopData' + time + '.json')
+    result = s3_session_object.put(Body=json)
+    extracted_status_code = result["ResponseMetadata"]["HTTPStatusCode"]
+    if int(extracted_status_code) >= 400:
+        print("Something went wrong. Please make sure that you are using an active key,"
+              " and that the bucket 'floop-dataset' exists in your VPC" + str(extracted_status_code))
+    else:
+        print("Success! Result of put operation was HTTP Status Code " + str(extracted_status_code))
+
+
 def initalize_connection(cert_path):
     cred_obj = firebase_admin.credentials.Certificate(cert_path)
     # initialize default app for firebase
     firebase_admin.initialize_app(cred_obj)
     db = firestore.client()
     # exclude certain types of comment, on Floop's suggestion
-    return db.collection(u'Databases/Dev_Database/Conversations').where('Comment_Preview', 'not-in', [
-        'What is your goal for this year?', 'Audio Comment', 'Freeform', 'Freeform Comment', '', ' ']).limit(
-        1000).stream()
+    return db.collection(u'Databases/Dev_Database/Conversations')\
+        .where('Comment_Preview',
+               'not-in',
+               ['What is your goal for this year?', 'Audio Comment', 'Freeform', 'Freeform Comment', '', ' '])\
+        .limit(10).stream()
+
 
 # descend into the tree of document -> collection -> document and pull out salient text
 if __name__ == '__main__':
     arr = []
-    cert_path = get_credentials()
+    cert_path = sys.argv[1] if len(sys.argv) > 1 else get_credentials()
     conversation_documents = initalize_connection(cert_path)
     for convo_doc in conversation_documents:
         all_messages = convo_doc.reference.collection('Messages').order_by(u'Date_Submitted').limit(1).get()
+        if not all_messages:
+            continue
         message_doc = all_messages[0]
         arr.append(message_doc._data["Text"])
-    with open('floop_data.json', 'w') as f:
-        de_dup_list = set(arr)
-        json.dump(list(de_dup_list), f)
+
+    de_dup_list = set(arr)
+    upload_s3(json.dumps(list(de_dup_list)))


### PR DESCRIPTION
Update to write directly to S3 from floop data collection script. I added some functionality so that the input steps can be bypassed by passing parameters to the script directly from the terminal like so:
`python3 floop_data_collection.py <path to your floop firebase pem file> <aws_access_key_id> <aws_secret_access_key>` 

For example, the path to my floop firebase pem file is: /Users/daleberg/Downloads/floop-firebase-development-firebase-adminsdk-g8bpy-8c72987529.json 

If you need help finding your key, you can follow the docs here: https://aws.amazon.com/blogs/security/wheres-my-secret-access-key/

You can confirm that the file was uploaded by checking the `floop-dataset` bucket, and looking for the file `floopData<$time_and_date_uploaded>.json`

Please let me know if you have any questions! I'll be happy to answer them. 

This PR fulfills requirements in https://github.com/North-Seattle-College/ad440-winter2022-tuesday-repo/issues/44