### PR TITLE
Create Automation for API Gateway

### DIFF
--- a/devops/makeAPIGateway/makeAPIGateway.sh
+++ b/devops/makeAPIGateway/makeAPIGateway.sh
@@ -1,0 +1,60 @@
+# !/bin/sh
+INITIALS_PROMPT="Please enter your first and last initial (or 'q' to quit)"
+NUM=2
+
+while :
+  do
+    # get and validate user initials
+    printf "%s\n" "$INITIALS_PROMPT" 
+    while read initials && [ "$initials" != "q" ];
+      do
+        # checks to see if string is null or has zero length
+        if [ -z "$initials" ]; then
+          printf '%s\n' "Error: initials can't be empty" 
+        # checks to see if the string matches the requested pattern
+        elif [[ "${initials}" =~ [^a-zA-Z] ]]; then
+          printf '%s\n' "Error: initials must only contain letters, a-z"
+        elif [[ "${#initials}" != $NUM ]]; then
+          printf '%s\n' "Error: initials must be $NUM characters"
+        else
+          break
+        fi
+          printf "%s\n" "$INITIALS_PROMPT" 
+      done
+
+    if [ "$initials" == "q" ]; then
+      printf '%s\n' "Done"
+      break
+    fi
+
+
+    # converts initials to lowercase and remove spaces
+    formattedInitials="$(echo "${initials}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    todayDate=$(date +'%Y%m%d')
+    # generates a random string https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
+    randomString=$(cat /dev/urandom | base64 | tr -dc 'a-z0-9' | fold -w 5 | head -n 1) 
+    uniqueName=$formattedInitials-$randomString-$todayDate
+    lambdaName=$uniqueName-api
+    stackName=$uniqueName-stack
+
+    printf "%s\n" "Your API and stack will be named as follows:" \
+            "api: $lambdaName" \
+            "stack: $stackName" \
+            "Create API? (y/n)" 
+
+    apiTemplate="./makeAPIGateway.yml"
+    while read answer && [ "$answer" != "q" ];
+      do
+        if [ "$answer" == "y" ]; then
+          printf '%s\n' "aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName "
+          aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName 
+          break
+        elif [ "$answer" == "n" ]; then
+          break
+        else
+          printf "%s\n" "Create API? (y/n)"
+        fi
+      done
+    printf '%s\n' "Done" 
+    break
+  done 

--- a/devops/makeAPIGateway/makeAPIGateway.sh
+++ b/devops/makeAPIGateway/makeAPIGateway.sh
@@ -31,10 +31,10 @@ while :
     # converts initials to lowercase and remove spaces
     formattedInitials="$(echo "${initials}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
     todayDate=$(date +'%Y%m%d')
-    # generates a random string https://unix.stackexchange.com/questions/230673/how-to-generate-a-random-string
-    randomString=$(cat /dev/urandom | base64 | tr -dc 'a-z0-9' | fold -w 5 | head -n 1) 
-    uniqueName=$formattedInitials-$randomString-$todayDate
-    lambdaName=$uniqueName-api
+    OPENSSL_STRING=$(openssl rand -hex 3)
+    RANDOM_STRING=${OPENSSL_STRING:0:5}
+    uniqueName=$formattedInitials-$RANDOM_STRING-$todayDate
+    APIName=$uniqueName-mockapi
     stackName=$uniqueName-stack
 
     printf "%s\n" "Your API and stack will be named as follows:" \
@@ -46,8 +46,8 @@ while :
     while read answer && [ "$answer" != "q" ];
       do
         if [ "$answer" == "y" ]; then
-          printf '%s\n' "aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName "
-          aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName 
+          printf '%s\n' "aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName --parameter-overrrides APIName=$APIName"
+          aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName --parameter-overrides APIName=$APIName
           break
         elif [ "$answer" == "n" ]; then
           break

--- a/devops/makeAPIGateway/makeAPIGateway.yml
+++ b/devops/makeAPIGateway/makeAPIGateway.yml
@@ -11,7 +11,7 @@ Resources:
       Description: An API Gateway with a Mock Integration
       EndpointConfiguration:
         Types:
-          - PRIVATE
+          - REGIONAL
       Name: mock-api
 
   ApiGatewayResource:

--- a/devops/makeAPIGateway/makeAPIGateway.yml
+++ b/devops/makeAPIGateway/makeAPIGateway.yml
@@ -2,6 +2,11 @@ AWSTemplateFormatVersion: '2010-09-09'
 
 Description: AWS API Gateway with a Mock Integration
 
+Parameters: 
+  APIName: 
+    Description: Unique name of your Mock API.
+    Type: String
+
 Resources:
 
   ApiGatewayRestApi:
@@ -12,7 +17,8 @@ Resources:
       EndpointConfiguration:
         Types:
           - REGIONAL
-      Name: mock-api
+      Name: !Ref APIName  
+
 
   ApiGatewayResource:
     Type: AWS::ApiGateway::Resource

--- a/devops/makeAPIGateway/makeAPIGateway.yml
+++ b/devops/makeAPIGateway/makeAPIGateway.yml
@@ -1,0 +1,77 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: AWS API Gateway with a Mock Integration
+
+Resources:
+
+  ApiGatewayRestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      ApiKeySourceType: HEADER
+      Description: An API Gateway with a Mock Integration
+      EndpointConfiguration:
+        Types:
+          - PRIVATE
+      Name: mock-api
+
+  ApiGatewayResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt ApiGatewayRestApi.RootResourceId
+      PathPart: 'mock'
+      RestApiId: !Ref ApiGatewayRestApi
+
+  ApiGatewayMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      ApiKeyRequired: false
+      AuthorizationType: NONE
+      HttpMethod: POST
+      Integration:
+        ConnectionType: INTERNET
+        IntegrationResponses:
+          - ResponseTemplates:
+              application/json: "{\"message\": \"OK\"}"
+            SelectionPattern: '2\d{2}'
+            StatusCode: 200
+          - ResponseTemplates:
+              application/json: "{\"message\": \"Internal Server Error\"}"
+            SelectionPattern: '5\d{2}'
+            StatusCode: 500
+        PassthroughBehavior: WHEN_NO_TEMPLATES
+        RequestTemplates:
+          application/json: "{\"statusCode\": $input.json('$.statusCode'), \"message\": $input.json('$.message')}"
+        Type: MOCK
+        TimeoutInMillis: 29000
+      MethodResponses:
+        - ResponseModels:
+            application/json: !Ref ApiGatewayModel
+          StatusCode: 200
+        - ResponseModels:
+            application/json: !Ref ApiGatewayModel
+          StatusCode: 500
+      OperationName: 'mock'
+      ResourceId: !Ref ApiGatewayResource
+      RestApiId: !Ref ApiGatewayRestApi
+
+  ApiGatewayModel:
+    Type: AWS::ApiGateway::Model
+    Properties:
+      ContentType: 'application/json'
+      RestApiId: !Ref ApiGatewayRestApi
+      Schema: {}
+
+  ApiGatewayStage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      DeploymentId: !Ref ApiGatewayDeployment
+      Description: Mock API Stage v0
+      RestApiId: !Ref ApiGatewayRestApi
+      StageName: 'v0'
+
+  ApiGatewayDeployment:
+    Type: AWS::ApiGateway::Deployment
+    DependsOn: ApiGatewayMethod
+    Properties:
+      Description: Mock API Deployment
+      RestApiId: !Ref ApiGatewayRestApi


### PR DESCRIPTION
## Description
As a developer, I want to write a script that creates an API gateway, so I don't have to manually do it myself.
Closes #56 
## Testing Steps
**Prerequisite**
•	  Must have [AWS CLI](https://aws.amazon.com/cli/) set up with your credentials

**Creating the API Gateway that contains a Mock API**
- [ ]	  Open a terminal window running bash
- [ ]	  Navigate to the makeAPIGateway folder
- [ ]	  Run ./makeAPIGateway.sh
- [ ]	  Follow the prompts to enter your first and last initial (image 1)
- [ ]	  View the automatically generated names for the API Gateway and Mock API
- [ ]	  Enter y to confirm creation of REST API and API Gateway, or enter n to exit the program
- [ ]	  If y is entered, an API Gateway containing Mock REST API will be deployed
- [ ]	  After stack has been created, Navigate to the AWS console 
- [ ]	  Search API Gateway to view created APIs, and confirm newly created Mock REST API is present (image 2)

## Images
1.	The script in the terminal
![PRP1](https://user-images.githubusercontent.com/75229373/154178150-14b4d94c-1d8c-4d35-b19f-cdb17acb65d3.PNG)

2.	The generated mock api and api gateway on AWS console
![PRP2](https://user-images.githubusercontent.com/75229373/154178162-152a9e96-4e73-4574-bd48-773c1c801dd8.PNG)

## Known Issues
This script is a shell script, and will not work if you are not using bash in your terminal. If you are using powershell, you can configure your computer to run bash on Windows.
