### PR TITLE
Update script to retrieve full conversations

### DIFF
--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -54,7 +54,6 @@ def upload_s3(json, key, secret):
         print(
             "Success! Result of put operation was HTTP Status Code " +
             str(extracted_status_code))
-    print('all good!')
 
 
 def initalize_connection(cert_path, doc_count=BATCH_LIMIT):

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -66,6 +66,7 @@ def upload_s3(json, key, secret):
             "Success! Result of put operation was HTTP Status Code " +
             str(extracted_status_code))
 
+
 def get_db_path(env):
     if env == 'prod':
         return 'Prod'
@@ -83,16 +84,18 @@ def initalize_connection(cert_path, env=DEV, doc_count=BATCH_LIMIT):
 
     limit = BATCH_LIMIT if doc_count > BATCH_LIMIT else doc_count
     # exclude certain types of comment, on Floop's suggestion
-    return db\
-        .collection(u'Databases/{0}_Database/Conversations'.format(get_db_path(env)))\
-        .where('Comment_Preview',
-               'not-in',
-               ['What is your goal for this year?',
-                'Audio Comment',
-                'Freeform',
-                'Freeform Comment',
-                '', ' '])\
-        .limit(limit)
+    return db .collection(
+        u'Databases/{0}_Database/Conversations'.format(
+            get_db_path(env))) .where(
+        'Comment_Preview',
+        'not-in',
+        [
+            'What is your goal for this year?',
+            'Audio Comment',
+            'Freeform',
+            'Freeform Comment',
+            '',
+            ' ']) .limit(limit)
 
 
 def get_conversations(query, limit, conversations=[], dupe_list=[], count=0):
@@ -155,7 +158,12 @@ def get_script_args():
                         help='number of conversation docs to query')
     parser.add_argument('--key', '-k', type=str, help='AWS access key')
     parser.add_argument('--secret', '-s', type=str, help='AWS secret key')
-    parser.add_argument('--env', '-e', type=str, choices=ENVS)
+    parser.add_argument(
+        '--env',
+        '-e',
+        type=str,
+        help='the alias for the firebase project to target',
+        choices=ENVS)
 
     args = parser.parse_args()
     return args

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -4,6 +4,7 @@ import boto3
 import json
 import argparse
 import scrubadub
+import scrubadub_spacy
 
 from datetime import datetime
 from firebase_admin import firestore
@@ -20,6 +21,7 @@ ENVS = [DEV, STAGING, PROD]
 
 scrubber = scrubadub.Scrubber()
 scrubber.add_detector(scrubadub.detectors.DateOfBirthDetector)
+scrubber.add_detector(scrubadub_spacy.detectors.SpacyEntityDetector)
 
 
 def get_credentials():

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -165,8 +165,7 @@ def get_script_args():
         help='the alias for the firebase project to target',
         choices=ENVS)
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 if __name__ == '__main__':

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -85,22 +85,20 @@ def get_conversations(query, limit, conversations=[], dupe_list=[], count=0):
 
         convo_data = convo_doc.to_dict()
         student_id = convo_data['Submission_Owner']
-
-        all_messages = convo_doc.reference.collection('Messages')\
-            .order_by(u'Date_Submitted').get()
-        if not all_messages:
-            continue
-
-        top_doc = all_messages[0]
-        top_doc_text = top_doc._data["Text"]
+        top_doc_text = convo_data["Comment_Preview"].strip()
 
         # ignore this conversation if top message is not unique
         if top_doc_text in current_dupe_list:
             continue
 
+        current_dupe_list.append(top_doc_text)
+        all_messages = convo_doc.reference.collection('Messages')\
+            .order_by(u'Date_Submitted').get()
+        if not all_messages:
+            continue
+
         conversation = []
 
-        current_dupe_list.append(top_doc_text)
         for message_doc in all_messages:
             message_data = message_doc.to_dict()
             sender_is_student = student_id == message_data["Sender_ID"]

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -27,7 +27,7 @@ def connect_s3(key, secret):
     https://docs.aws.amazon.com/STS/latest/APIReference/API_Credentials.html
     '''
 
-    while not re.match("\w{16,128}", key_id):
+    while not re.match("\\w{16,128}", key_id):
         print("Key in incorrect format, please try again")
         key_id = input("re-enter your key: ")
     secret_key = secret if secret else input(
@@ -45,10 +45,15 @@ def upload_s3(json, key, secret):
     result = s3_session_object.put(Body=json)
     extracted_status_code = result["ResponseMetadata"]["HTTPStatusCode"]
     if int(extracted_status_code) >= 400:
-        print("Something went wrong. Please make sure that you are using an active key,"
-              " and that the bucket 'floop-dataset' exists in your VPC" + str(extracted_status_code))
+        print(
+            "Something went wrong. Please make sure that you are using an \
+                active key,"
+            " and that the bucket 'floop-dataset' exists in your VPC" +
+            str(extracted_status_code))
     else:
-        print("Success! Result of put operation was HTTP Status Code " + str(extracted_status_code))
+        print(
+            "Success! Result of put operation was HTTP Status Code " +
+            str(extracted_status_code))
     print('all good!')
 
 
@@ -106,7 +111,7 @@ def get_conversations(query, limit, conversations=[], dupe_list=[], count=0):
             conversation.append({
                 "Text": message_data["Text"],
                 "Sender_Type": sender_type
-                })
+            })
         current_conversations.append(conversation)
         conversation_count += 1
         print('{0}/{1} conversations processed'
@@ -146,4 +151,5 @@ if __name__ == '__main__':
 
     data = get_conversations(query, doc_limit)
     upload_s3(json.dumps(data), args.key, args.secret)
+
     print('Done')

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -111,8 +111,9 @@ def get_conversations(query, limit, conversations=[], dupe_list=[], count=0):
                 })
         current_conversations.append(conversation)
         conversation_count += 1
-    print('{0}/{1} conversations processed'
-          .format(conversation_count, limit), end='\r')
+        print('{0}/{1} conversations processed'
+              .format(conversation_count, limit), end='\r')
+
     if conversation_count < limit:
         last_doc = query_results[-1]
         return get_conversations(

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -2,13 +2,18 @@ import firebase_admin
 import re
 import boto3
 import json
+import argparse
+import scrubadub
+
 from datetime import datetime
 from firebase_admin import firestore
-import argparse
 from os.path import exists
 
 BATCH_LIMIT = 500
 DEFAULT_DOC_LIMIT = 1000
+
+scrubber = scrubadub.Scrubber()
+scrubber.add_detector(scrubadub.detectors.DateOfBirthDetector)
 
 
 def get_credentials():
@@ -108,7 +113,7 @@ def get_conversations(query, limit, conversations=[], dupe_list=[], count=0):
             sender_is_student = student_id == message_data["Sender_ID"]
             sender_type = "Student" if sender_is_student else "Teacher"
             conversation.append({
-                "Text": message_data["Text"],
+                "Text": scrubber.clean(message_data["Text"]),
                 "Sender_Type": sender_type
             })
         current_conversations.append(conversation)

--- a/backend/data/floop_data_collection.py
+++ b/backend/data/floop_data_collection.py
@@ -68,9 +68,9 @@ def upload_s3(json, key, secret):
 
 
 def get_db_path(env):
-    if env == 'prod':
+    if env == PROD:
         return 'Prod'
-    elif env == 'staging':
+    elif env == STAGING:
         return 'Test'
     else:
         return 'Dev'

--- a/backend/data/requirements.txt
+++ b/backend/data/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.21.0
 firebase-admin==5.2.0
 argparse==1.4.0
+scrubadub==2.0.0

--- a/backend/data/requirements.txt
+++ b/backend/data/requirements.txt
@@ -1,0 +1,3 @@
+boto3==1.21.0
+firebase-admin==5.2.0
+argparse==1.4.0

--- a/backend/data/requirements.txt
+++ b/backend/data/requirements.txt
@@ -2,3 +2,4 @@ boto3==1.21.0
 firebase-admin==5.2.0
 argparse==1.4.0
 scrubadub==2.0.0
+scrubadub-spacy==2.0.0


### PR DESCRIPTION
# Description 🗒️ 
 🚨 The production data is available in our `floop-dataset` S3 bucket, object `floopData02-16-2022-21-06-37.json` 🚨 

Closes #54 
This PR makes many changes to the script. See below:

## Data structure 🏗️
The full conversations are now returned by the script. They look like this:
```ts
[
    [ // convo 1
        { "Text": string, Sender_Type: 'Teacher' },
        { "Text": string, Sender_Type: 'Student' | 'Teacher' },
        ...
        { "Text": string, Sender_Type: 'Student' | 'Teacher' },
    ],
    [ // convo 2
        { "Text": string, Sender_Type: 'Teacher' },
        { "Text": string, Sender_Type: 'Student' | 'Teacher' },
        ...
        { "Text": String, Sender_Type: 'Student' | 'Teacher' },
    ],
]
```
* Each nested array represents a conversation
* The first object in each nested array is the initial message from the Teacher. The rest of the messages are ordered by date

## Command line args 🎯 
The following optional arguments have been added:
* `--path`: path to your firebase cert file
* `--limit`: the total number of non-duplicate conversations to query (default=1000)
    * _Note: We're not limited to any specific doc count, the script has been refactored to work with any number of docs queried_
* `--key`: your AWS key
* `--secret`: your AWS secret
* `--env`: the firebase project alias to target. Can be `dev`, `staging`, or `prod` (default='dev')


## Data cleaning 🧹 
Added [scrubadub](https://github.com/LeapBeyond/scrubadub) to check for and remove any PII. The scrubber looks for urls, emails, names, and other entities. If the scrubber replaces something, it will look like this:
```ts
[
    {
        "Text": "Hi, {{NAME}}. Please fill out the survey here: {{URL}}.", 
        "Sender_Type": "Teacher"
    },
    {
        "Text": "{{ORGANIZATION}} email is {{EMAIL}}", 
        "Sender_Type": "Teacher"
    },
] 
```

The scrubber is pretty aggressive, so some messages that are heavily redacted might need to be ignored.

## Formatting 💅 
Formats file using [autopep8](https://github.com/hhatto/autopep8)

If you have it installed, you can format a python file with: 
```bash
$ autopep8 --in-place --aggressive --aggressive <filename>
```

# Gallery 📷 
Example run using all the optional arguments
<img width="600" alt="Screen Shot 2022-02-16 at 5 53 09 PM" src="https://user-images.githubusercontent.com/30481844/154390363-99390ae8-9840-4c25-aceb-7607c5e1a10e.png">

Showing the CLI documentation
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30481844/154392288-3fb46ebb-8eb9-4e1d-962f-a117b34c5ecd.png">


# Testing 🧪 

## Pre-reqs
* Running this script requires Python 3.9
* You need a dev database cert file from Floop. If you don't have one, please DM me and I'll share one with you.

## Steps
1. Navigate to `/backend/data` from the root of the repo
2. Activate a virtual environment and run `pip install -r requirements.txt`
3. Run the script using the below example as a template:
    ```bash
    $ python floop_data_collection.py --path <path-to-service-account-file> --key <your-aws-access-key> --secret <your-aws-secret-key> --limit 100
    ```
4. You should see the conversations processed count go up in the terminal. Once complete, you should be able to find the file in the `floop-dataset` S3 bucket


# Known Issues ⚠️ 
You'll see a few warnings in the terminal when running the script, for example: 

> /Users/danjack/Documents/GitHub/floopContainer/ad440-winter2022-tuesday-repo/backend/.venv/lib/python3.9/site-packages/dateparser/date_parser.py:35: PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html

This is caused by a dependency within `scrubadub` and not something we can address.

Another thing you'll see because of `scrubadub` is a package installation for a model, see [SpactEntityDetector](https://scrubadub.readthedocs.io/en/stable/api_scrubadub_detectors.html#scrubadub-spacy-detectors-spacyentitydetector) for more info on the model.
<img width="600" alt="image" src="https://user-images.githubusercontent.com/30481844/154427212-d9079f7c-83c1-4eb3-b1ee-c5cdd82cb0a3.png">


