### PR TITLE
Implement Script to Do Some Clustering by Number of Threads in Conver…

### DIFF
--- a/backend/clustering_algorithm/conversation_clustering.py
+++ b/backend/clustering_algorithm/conversation_clustering.py
@@ -1,0 +1,64 @@
+import json
+import os.path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.model_selection import train_test_split
+
+
+# return a simplified xy dict, with just the values we need for K-means clustering
+def define_xy(df):
+    y = df['comparison_metric'].values
+    X = df['length_of_thread'].values
+    return {'y': y.reshape(-1, 1), 'X': X.reshape(-1, 1)}
+
+
+# split the data into test sets and train sets, 80/20
+def test_train_split(xy_dict):
+    X_train, X_test, y_train, y_test = train_test_split(xy_dict['X'], xy_dict['y'],
+                                                        test_size=0.2, random_state=42,
+                                                        stratify=xy_dict['y'])
+    return {"X_train": X_train, "X_test": X_test, "y_train": y_train, "y_test": y_test}
+
+
+# we'll fill this out when we know what it is in the thread we want to correlate with length
+def get_metric_from_thread(thread):
+    return 0
+
+
+# won't give us a usable prediction until we have a correlation metric
+def build_classifier(xy_dict):
+    knn = KNeighborsClassifier(n_neighbors=6)
+    knn.fit(xy_dict['X'], xy_dict['y'])
+    y_pred = knn.predict(xy_dict['X'])
+    print("Prediction: {}".format(y_pred))
+
+
+if __name__ == '__main__':
+    # 2 dictionaries so that we don't operate on the comments dictionary
+    file_path = input("Please enter filepath to floop data: ")
+    if not os.path.exists(file_path):
+        raise FileNotFoundError("Invalid entry for file path")
+    comments_dict = json.load(open(file_path, "r"))
+    # count number of comments in each conversation
+    counts_dict = {}
+    for thread in comments_dict:
+        length = len(thread)
+        if counts_dict.get(length):
+            counts_dict[length] = int(counts_dict[length]) + 1
+        else:
+            counts_dict[length] = 1
+
+    # build an array of dictionaries to process next steps
+    parsed_data_array = [{"thread": str(thread), "comparison_metric": get_metric_from_thread(thread),
+                          "length_of_thread": len(thread), "conversations_with_same_len": counts_dict.get(len(thread))}
+                         for thread in comments_dict]
+
+    # build a dataframe, and plot it so that we can see the "clusters" of the distribution of conversation lengths
+    df = pd.DataFrame(parsed_data_array)
+    df.plot.scatter(x="length_of_thread", y="conversations_with_same_len", s=100)
+    plt.show()
+
+    build_classifier(define_xy(df))
+


### PR DESCRIPTION
We want to do some clustering of conversations by length, which this script does, but to keep things interesting, I took it a little further. We probably want to correlate the length of a conversation with some other variable, like the sum of the sentiment scores of each of the threads in the conversation. Since we don't know what we want the corresponding variable to be yet, I implemented a placeholder, `comparison_metric` so that we can easily plug it in when we need it. 

Work Ticket: #84 

How to Test: 

1. Go to the S3 console, and download the most recent file from the `floop-dataset` bucket. Whichever one should work, but the most recent one will show a more interesting distribution of values. 
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/46502783/155468839-4ed41da7-d1e7-4443-8b77-5b5fe7d94dbf.png">

2. Run the script and give it the file path of the file you just downloaded

4. you'll see something like this:
<img width="642" alt="image" src="https://user-images.githubusercontent.com/46502783/155469117-efa7f379-752b-47f9-af0e-5d87a2ac693c.png">

and there ya go! a distribution of conversations by number of threads. You'll also see an output of a prediction with a bunch of zero values. That's because the correlated variable is set like so:
```
def get_metric_from_thread(thread):
    return 0
```
once we know what to give the KMeans functionality, we can build that function and then we're done 🥳

