### PR TITLE
Rendering the API response object

### DIFF
--- a/frontend/floop_feedback/src/components/FeedbackText.js
+++ b/frontend/floop_feedback/src/components/FeedbackText.js
@@ -17,6 +17,7 @@ function FeedbackText ({feedback, setFeedback, setEmpty}) {
                   setFeedback(e.target.value)
                   setEmpty(true)
               }
+              console.log(feedback)
             }}
           />
         </div>

--- a/frontend/floop_feedback/src/components/FeedbackText.js
+++ b/frontend/floop_feedback/src/components/FeedbackText.js
@@ -17,7 +17,6 @@ function FeedbackText ({feedback, setFeedback, setEmpty}) {
                   setFeedback(e.target.value)
                   setEmpty(true)
               }
-              console.log(feedback)
             }}
           />
         </div>

--- a/frontend/floop_feedback/src/components/SubmitButton.js
+++ b/frontend/floop_feedback/src/components/SubmitButton.js
@@ -6,12 +6,10 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ feedback }),
-      mode: 'no-cors'
     };
     e.preventDefault();
     fetch('https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda', requestConfig)
       .then(response => {
-        console.log(response);
         if(!response.ok) {
           setError('Network response not ok');
         }
@@ -21,7 +19,6 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
         setResponse(data);
       })
       .catch(err => { setError(err) });
-      console.log(feedback, requestConfig, typeof feedback);
   }
   return (
     <div>

--- a/frontend/floop_feedback/src/components/SubmitButton.js
+++ b/frontend/floop_feedback/src/components/SubmitButton.js
@@ -1,16 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 function SubmitButton({empty, feedback, setResponse, setError}) {
   const inputSubmit = e => {
     const requestConfig = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ feedback })
+      body: JSON.stringify({ feedback }),
+      mode: 'no-cors'
     };
+    console.log(requestConfig, typeof feedback);
     e.preventDefault();
     fetch('https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda', requestConfig)
-    //fetch('https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test', requestConfig)
       .then(response => {
+        console.log(response);
         if(!response.ok) {
           setError('Network response not ok');
         }

--- a/frontend/floop_feedback/src/components/SubmitButton.js
+++ b/frontend/floop_feedback/src/components/SubmitButton.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 function SubmitButton({empty, feedback, setResponse, setError}) {
   const inputSubmit = e => {
@@ -8,7 +8,6 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
       body: JSON.stringify({ feedback }),
       mode: 'no-cors'
     };
-    console.log(requestConfig, typeof feedback);
     e.preventDefault();
     fetch('https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda', requestConfig)
       .then(response => {
@@ -22,6 +21,7 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
         setResponse(data);
       })
       .catch(err => { setError(err) });
+      console.log(feedback, requestConfig, typeof feedback);
   }
   return (
     <div>

--- a/frontend/floop_feedback/src/components/SubmitButton.js
+++ b/frontend/floop_feedback/src/components/SubmitButton.js
@@ -8,7 +8,8 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
       body: JSON.stringify({ feedback })
     };
     e.preventDefault();
-    fetch('https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test', requestConfig)
+    fetch('https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda', requestConfig)
+    //fetch('https://9u4xt4nqr1.execute-api.us-west-2.amazonaws.com/default/test', requestConfig)
       .then(response => {
         if(!response.ok) {
           setError('Network response not ok');


### PR DESCRIPTION
Closes #89 

#### User story, Acceptance Criteria, Time Spent on Issue and estimated time details are in issue #89 

## Location
The API url is used from [PR 109](https://github.com/North-Seattle-College/ad440-winter2022-tuesday-repo/pull/109). 
It's located in `/frontend/floop_feedback/components/SubmitButton.js ` on line 11

<img width="1097" alt="Screen Shot 2022-03-01 at 8 44 01 PM" src="https://user-images.githubusercontent.com/74215044/156296563-1851102b-b4f9-478f-b568-e641c6e8e2cd.png">


## To test:

- [ ] 1. Checkout the branch `mf-apiResponse`
- [ ] 2. Go to the `frontend/floop_feedback` folder 


- [ ] 3. Run `npm start` in terminal
- [ ] 4. When the localhost window opens, open the Web Developer Tools 
<img width="1004" alt="Screen Shot 2022-03-01 at 8 40 03 PM" src="https://user-images.githubusercontent.com/74215044/156296320-b9e646ce-e826-4b82-9e5f-3f5680e02a37.png">

- [ ] 5. Click the Network tab on Web Developer Tools
<img width="1420" alt="Screen Shot 2022-03-01 at 8 46 25 PM" src="https://user-images.githubusercontent.com/74215044/156296863-24a53fdf-2c2b-4efe-af1f-0148e5fa783c.png">

- [ ] 6. Input text in the text box and click submit
- [ ] 7. In the Method tab, Options and Post should both be red and have the following an error messages: 
      
     - `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda. (Reason: CORS header ‘Access-Control-Allow-Origin’ missing). Status code: 500.`
      
     - `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda. (Reason: CORS request did not succeed). Status code: (null).`
<img width="1428" alt="Screen Shot 2022-03-01 at 8 49 10 PM" src="https://user-images.githubusercontent.com/74215044/156297082-ab9c2fa8-28f4-4f8f-8eb6-48c4e860c38c.png">


## Troubleshooting:
Type `npm i` in Terminal within the `/frontend/floop_feedback/` folder then `npm start` if `npm start `doesn't work right away.
