### PR TITLE
Refactor script to analyze single comment threads

### DIFF
--- a/backend/clustering_algorithm/conversation_clustering.py
+++ b/backend/clustering_algorithm/conversation_clustering.py
@@ -1,64 +1,89 @@
 import json
 import os.path
+import re
 
-import matplotlib.pyplot as plt
+import nltk
+from nltk.corpus import stopwords
+from nltk.sentiment import SentimentIntensityAnalyzer
+from nltk.tokenize import word_tokenize
+from nltk.stem import WordNetLemmatizer
 import pandas as pd
-from sklearn.neighbors import KNeighborsClassifier
-from sklearn.model_selection import train_test_split
+
+def download_nltk_deps():
+    nltk.download('stopwords')
+    nltk.download('punkt')
+    nltk.download('wordnet')
+    nltk.download('omw-1.4')
+    nltk.download('vader_lexicon')
 
 
-# return a simplified xy dict, with just the values we need for K-means clustering
-def define_xy(df):
-    y = df['comparison_metric'].values
-    X = df['length_of_thread'].values
-    return {'y': y.reshape(-1, 1), 'X': X.reshape(-1, 1)}
+def insights_from_threads_of_one(comments_list):
+    single_comment_threads = filter(lambda thread: len(thread) == 1, comments_list)
+    single_comment_threads_parsed = [{"comment": str(comment[0]["Text"].strip()), "length_of_comment": len(comment[0]["Text"].strip()),
+                                      "sentiment_score": get_sentiment_score(comment[0]["Text"])}
+                                     for comment in single_comment_threads]
+    df = pd.DataFrame(single_comment_threads_parsed)
 
 
-# split the data into test sets and train sets, 80/20
-def test_train_split(xy_dict):
-    X_train, X_test, y_train, y_test = train_test_split(xy_dict['X'], xy_dict['y'],
-                                                        test_size=0.2, random_state=42,
-                                                        stratify=xy_dict['y'])
-    return {"X_train": X_train, "X_test": X_test, "y_train": y_train, "y_test": y_test}
+
+    print("The comment with the `most positive sentiment` in this set is: " + str(df.iloc[df["sentiment_score"].idxmax()]["comment"]))
+    print("The comment with the `most negative sentiment` in this set is: " + str(df.iloc[df["sentiment_score"].idxmin()]["comment"]))
 
 
-# we'll fill this out when we know what it is in the thread we want to correlate with length
-def get_metric_from_thread(thread):
-    return 0
+    scores = df["sentiment_score"]
+    comment_len = df["length_of_comment"]
+    print("The modal sentiment score is: " + str(scores.mode()))
+    print("The mean sentiment score is: " + str(scores.mean()))
+    print("The median sentiment score is: " + str(scores.median()))
+    print("Standard deviation from the mean of sentiment scores for threads containing one comment: "
+          + str(scores.std()))
 
+    print()
+    print()
+    print("The mean length of comment in single comment threads is: " + str(comment_len.mean()))
+    print("The median length comment in single comment threads is: " + str(comment_len.median()))
+    print("Standard deviation from the mean of sentiment scores for threads containing one comment: "
+          + str(comment_len.std()))
+    print()
+    print()
 
-# won't give us a usable prediction until we have a correlation metric
-def build_classifier(xy_dict):
-    knn = KNeighborsClassifier(n_neighbors=6)
-    knn.fit(xy_dict['X'], xy_dict['y'])
-    y_pred = knn.predict(xy_dict['X'])
-    print("Prediction: {}".format(y_pred))
+    return len(df["comment"])
 
+def get_sentiment_score(comment):
+    lemmatizer = WordNetLemmatizer()
+    eng_stop_words = stopwords.words('english')
+    comment_lowered = str(comment).lower()
+    comment_lowered_processed = re.sub('[^a-zA-Z]+', ' ', comment_lowered).strip()
+    tokens = word_tokenize(comment_lowered_processed)
+    words = [t for t in tokens if t not in eng_stop_words]
+    lemmatized_words = [lemmatizer.lemmatize(w) for w in words]
+    sentiment_analyzer = SentimentIntensityAnalyzer()
+    sentiment_score = 0
+    for word in lemmatized_words:
+        sentiment_score += sentiment_analyzer.polarity_scores(word)["compound"]
+    return sentiment_score
 
 if __name__ == '__main__':
-    # 2 dictionaries so that we don't operate on the comments dictionary
-    file_path = input("Please enter filepath to floop data: ")
+    download_nltk_deps()
+    # 2 dictionaries so that we don't operate on any single comments dictionary
+    file_path = input("Please enter file path to floop dataset: ")
     if not os.path.exists(file_path):
         raise FileNotFoundError("Invalid entry for file path")
-    comments_dict = json.load(open(file_path, "r"))
+    comments_list = json.load(open(file_path, "r"))
+
     # count number of comments in each conversation
     counts_dict = {}
-    for thread in comments_dict:
+    for thread in comments_list:
         length = len(thread)
         if counts_dict.get(length):
             counts_dict[length] = int(counts_dict[length]) + 1
         else:
             counts_dict[length] = 1
 
-    # build an array of dictionaries to process next steps
-    parsed_data_array = [{"thread": str(thread), "comparison_metric": get_metric_from_thread(thread),
-                          "length_of_thread": len(thread), "conversations_with_same_len": counts_dict.get(len(thread))}
-                         for thread in comments_dict]
+    number_of_single_comment_threads = insights_from_threads_of_one(comments_list)
 
-    # build a dataframe, and plot it so that we can see the "clusters" of the distribution of conversation lengths
-    df = pd.DataFrame(parsed_data_array)
-    df.plot.scatter(x="length_of_thread", y="conversations_with_same_len", s=100)
-    plt.show()
+    print("Proportion of threads with single comment: " + str(number_of_single_comment_threads) + "/"
+          + str(len(comments_list)))
 
-    build_classifier(define_xy(df))
+
 


### PR DESCRIPTION
**User Story**
As a developer, I want to be able to run a simple script to glean insights into conversations that teachers and students are having on the Floop platform. 

**Estimated time to complete**
4 hours

**Actual time to complete**
4 hours

**Additional Context**
Previously, we found that the overwhelming majority of conversations have one comment, from the teacher. After consulting with the Floop team, they confirmed that gleaning some insights into single comment conversations would be most valuable for them (sentiment, verbosity, simple statistics for those characteristics are good enough). 

My findings confirm my suspicions: sentiment scores are not a reliable metric for Floop as they experiment with NLP techniques to determine the efficacy of a given comment in a conversation. The reason for this, is that teachers and students are discussing homework assignments in these conversations. If the subject of the assignment is negative, then the comment will have some negative "sentiment", even if the teacher is being supportive. For instance, if I pass this sentence to the NLTK sentiment analyzer - "You did an excellent job of documenting the atrocities of the horrible war" - it will return this result - `{'neg': 0.351, 'neu': 0.474, 'pos': 0.175, 'compound': -0.5719}` - a negative compound score, and a general skew toward this being a neutral/negative comment. This is at odds with the nature of the teacher's feedback. Similarly problematic is the fact that that language teachers use Floop to grade their student's homework, in the language that they are teaching. Using standard NLP approaches, we'll have to make provisions for each language to avoid accidentally scoring a non-english comment as very positive/negative simply because the analyzer doesn't know what to do. 

Generally, single comment threads seem to be pretty short, as you'd expect. The median length in characters of all the single comments threads in the largest data set available to me is 34, with a standard deviation of 49. Since these are single characters, that is a relatively small amount of spread, even at two standard deviations. 

**Testing**
Both the development and production data-sets are available in our floop-dataset S3 bucket.

To test the script, download any file from the floop-dataset repo and enter the path to that file when the script prompts you to.

**Result**
The script outputs a simple report of insights which look something like this:

```
The comment with the `most positive sentiment` in this set is: If the temperature in a pond is lower, then the dissolved oxygen will be higher because gas escapes mor    e readily in liquids at high temperature due to increased movement of kinetic energy (= increased movement of molecules)

The comment with the `most negative sentiment` in this set is: (8) In Tamil Nadu this movement took a violent form .           (7) The central government responded by agreeing to continue the                 use   of English along with Hi    ndi for official purposes.

The modal sentiment score is: 0    0.0
The mean sentiment score is: 0.04912222222222222
The median sentiment score is: 0.0
Standard deviation from the mean of sentiment scores for threads containing one comment: 0.25924739042938205


The mean length of comment in single comment threads is: 90.66666666666667
The median length comment in single comment threads is: 50.0
Standard deviation from the mean of sentiment scores for threads containing one comment: 88.04402307936638

Proportion of threads with single comment: 9/11
```

**Acceptance Criteria**

- [x] Script returns meaningful insights into conversations that students are having with their teachers on the floop platform
- [x] Confirmed with Jack that insights are helpful

