### PR TITLE
Add cloudformation template and script for dynamo db creation

### DIFF
--- a/devops/makeDynamoDb/makeDynamoDb.bash
+++ b/devops/makeDynamoDb/makeDynamoDb.bash
@@ -2,6 +2,7 @@
 INITIALS_PROMPT="Please enter your first and last initial (or 'q' to quit)"
 NUM=2
 
+
 while :
   do
     # get and validate user initials
@@ -46,8 +47,8 @@ while :
     while read answer && [ "$answer" != "q" ];
       do
         if [ "$answer" == "y" ]; then
-          printf '%s\n' "aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrrides DatabaseName=$databaseName"
-          aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrides DatabaseName="new"
+          printf '%s\n' "aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrrides DatabaseName=$uniqueName" >&1
+          aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrides DatabaseName=$uniqueName
           break
         elif [ "$answer" == "n" ]; then
           break

--- a/devops/makeDynamoDb/makeDynamoDb.bash
+++ b/devops/makeDynamoDb/makeDynamoDb.bash
@@ -1,0 +1,60 @@
+# !/bin/sh
+INITIALS_PROMPT="Please enter your first and last initial (or 'q' to quit)"
+NUM=2
+
+while :
+  do
+    # get and validate user initials
+    printf "%s\n" "$INITIALS_PROMPT" 
+    while read initials && [ "$initials" != "q" ];
+      do
+        # checks to see if string is null or has zero length
+        if [ -z "$initials" ]; then
+          printf '%s\n' "Error: initials can't be empty" 
+        # checks to see if the string matches the requested pattern
+        elif [[ "${initials}" =~ [^a-zA-Z] ]]; then
+          printf '%s\n' "Error: initials must only contain letters, a-z"
+        elif [[ "${#initials}" != $NUM ]]; then
+          printf '%s\n' "Error: initials must be $NUM characters"
+        else
+          break
+        fi
+          printf "%s\n" "$INITIALS_PROMPT" 
+      done
+
+    if [ "$initials" == "q" ]; then
+      printf '%s\n' "Done"
+      break
+    fi
+
+
+    # converts initials to lowercase and remove spaces
+    formattedInitials="$(echo "${initials}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    todayDate=$(date +'%Y%m%d')
+    OPENSSL_STRING=$(openssl rand -hex 3)
+    RANDOM_STRING=${OPENSSL_STRING:0:5}
+    uniqueName=$formattedInitials-$RANDOM_STRING-$todayDate
+    databaseName=$uniqueName-database
+    stackName=$uniqueName-stack
+
+    printf "%s\n" "Your Database and stack will be named as follows:" \
+            "db: $databaseName" \
+            "stack: $stackName" \
+            "Create DB? (y/n)" 
+
+    databaseTemplate="./makeDynamoDb.yml"
+    while read answer && [ "$answer" != "q" ];
+      do
+        if [ "$answer" == "y" ]; then
+          printf '%s\n' "aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrrides DatabaseName=$databaseName"
+          aws cloudformation deploy --template-file $databaseTemplate --stack-name $stackName --parameter-overrides DatabaseName="new"
+          break
+        elif [ "$answer" == "n" ]; then
+          break
+        else
+          printf "%s\n" "Create Dynamo DB? (y/n)"
+        fi
+      done
+    printf '%s\n' "Done" 
+    break
+  done 

--- a/devops/makeDynamoDb/makeDynamoDb.yml
+++ b/devops/makeDynamoDb/makeDynamoDb.yml
@@ -2,6 +2,9 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: AWS CloudFormation Template To Create a DynamoDB
 
 Parameters:
+  DatabaseName:
+    Type: String
+    Description: Table name, can't be empty
   HashKeyElementName:
     Type: String
     Default: Id
@@ -11,10 +14,10 @@ Parameters:
     Default: S
     Description: Hash Key Type
 Resources:
-  Ad440Dynamo:
+  DynamoTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: Ad440Dynamo
+      TableName: !Ref DatabaseName
       AttributeDefinitions:
         - 
           AttributeName: !Ref HashKeyElementName
@@ -27,6 +30,6 @@ Resources:
         ReadCapacityUnits: 5
         WriteCapacityUnits: 5 
 Outputs:
-  Employee:
+  Table:
     Description: Table Created using this template.
-    Value: !Ref Ad440Dynamo
+    Value: !Ref DatabaseName

--- a/devops/makeDynamoDb/makeDynamoDb.yml
+++ b/devops/makeDynamoDb/makeDynamoDb.yml
@@ -4,17 +4,17 @@ Description: AWS CloudFormation Template To Create a DynamoDB
 Parameters:
   HashKeyElementName:
     Type: String
-    Default: EmployeeId
+    Default: Id
     Description: Hash Key Name
   HashKeyElementType:
     Type: String
     Default: S
     Description: Hash Key Type
 Resources:
-  EmployeeTable:
+  Ad440Dynamo:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: Employee
+      TableName: Ad440Dynamo
       AttributeDefinitions:
         - 
           AttributeName: !Ref HashKeyElementName
@@ -29,4 +29,4 @@ Resources:
 Outputs:
   Employee:
     Description: Table Created using this template.
-    Value: !Ref EmployeeTable
+    Value: !Ref Ad440Dynamo

--- a/devops/makeDynamoDb/makeDynamoDb.yml
+++ b/devops/makeDynamoDb/makeDynamoDb.yml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS CloudFormation Template To Create a DynamoDB
+
+Parameters:
+  HashKeyElementName:
+    Type: String
+    Default: EmployeeId
+    Description: Hash Key Name
+  HashKeyElementType:
+    Type: String
+    Default: S
+    Description: Hash Key Type
+Resources:
+  EmployeeTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: Employee
+      AttributeDefinitions:
+        - 
+          AttributeName: !Ref HashKeyElementName
+          AttributeType: !Ref HashKeyElementType
+      KeySchema:
+        - 
+          AttributeName: !Ref HashKeyElementName
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5 
+Outputs:
+  Employee:
+    Description: Table Created using this template.
+    Value: !Ref EmployeeTable


### PR DESCRIPTION
Closes [#23](https://github.com/North-Seattle-College/ad440-winter2022-tuesday-repo/issues/23)

This PR adds a [Cloudformation](https://aws.amazon.com/cloudformation/) template for creating a new DynamoDB and Table, and a shell script to deploy it. 

This is what the script looks like after a successful deployment:
![Screenshot (113)](https://user-images.githubusercontent.com/15794743/159188679-71788da1-b650-4836-9f68-cec6c4b7ed83.png)

Here it is being shown in AWS:
![Screenshot (114)](https://user-images.githubusercontent.com/15794743/159188723-765f8ccb-ac1f-4225-bd98-6cb7e08d28a6.png)


# Testing

## Pre-reqs
* You need a `bash` or `zsh`. If you're on Windows, there are lots of guides for adding bash, [here's one](https://www.configserverfgithirewall.com/windows-10/install-bash-on-windows-10/)
* You must have the aws cli installed and it must be configured to use your access and secret key

## Steps
1. From the root of the repo, `cd devops/makeDynamoDb`
2. Run the following: `./makeDynamoDb.sh`
3. Enter your initials when prompted and press Enter
    * must only consist of letters a-z
    * can be no less than 2 chars
    * can be no more than 5 chars
4. You'll see a preview of your database and stack name. Confirm you want to create the stack and database by entering "y" and pressing Enter

# Activities Documentation

| Date  | Activity | Time Spent |
| ------------- | ------------- | ------------- |
| 01/17/2022 | Researching Cloudformation  | 2 hr  |
| 01/18/2022  | Testing | 0.5 hr  |
| 01/18/2022  | Documentation | 0.5 hr |
| 01/18/2022  | Researching shell scripts | 1 hr  |
| 01/18/2022  | Writing shell script | 0.5 hr  |

