### PR TITLE
Replace the POST endpoint with custom domain

### DIFF
--- a/frontend/floop_feedback/src/components/SubmitButton.js
+++ b/frontend/floop_feedback/src/components/SubmitButton.js
@@ -1,6 +1,7 @@
 import React from "react";
 
 function SubmitButton({empty, feedback, setResponse, setError}) {
+  const url = 'https://api.holodium.com/v1/feedback'
   const inputSubmit = e => {
     const requestConfig = {
       method: 'POST',
@@ -8,7 +9,7 @@ function SubmitButton({empty, feedback, setResponse, setError}) {
       body: JSON.stringify({ feedback }),
     };
     e.preventDefault();
-    fetch('https://d5z72uewg7.execute-api.us-west-2.amazonaws.com/test/kj-6exxg-20220222-lambda', requestConfig)
+    fetch(url, requestConfig)
       .then(response => {
         if(!response.ok) {
         }


### PR DESCRIPTION
Closes #155 

#### User story, Acceptance Criteria, Time Spent on Issue and estimated time details are in issue #155 

## Location
The custom domain API url used: https://api.holodium.com/v1/feedback 
It's located in `/frontend/floop_feedback/components/SubmitButton.js ` on line 4


<img width="803" alt="Screen Shot 2022-03-20 at 3 43 53 PM" src="https://user-images.githubusercontent.com/74215044/159189214-c8e0a256-b467-4f12-b8a2-24ca4e807cb1.png">


## To test:

- [x] 1. Checkout the branch `mf-issue155`

- [x] 2. Go to the `frontend/floop_feedback` folder 


- [x] 3. Run `npm start` in terminal
- [x] 4. When the localhost window opens, open the Web Developer Tools 
<img width="1004" alt="Screen Shot 2022-03-01 at 8 40 03 PM" src="https://user-images.githubusercontent.com/74215044/156296320-b9e646ce-e826-4b82-9e5f-3f5680e02a37.png">

- [x] 5. Click the Network tab on Web Developer Tools
<img width="1420" alt="Screen Shot 2022-03-01 at 8 46 25 PM" src="https://user-images.githubusercontent.com/74215044/156296863-24a53fdf-2c2b-4efe-af1f-0148e5fa783c.png">

- [x] 6. Input some text in the text box and click submit
- [x] 7. The analysis should appear under the buttons with sentence, question, and sentiment for each sentence. OPTIONS and POST should all have a 200 Status
<img width="1413" alt="Screen Shot 2022-03-20 at 3 38 11 PM" src="https://user-images.githubusercontent.com/74215044/159189002-de4012bc-ce55-479f-ba5e-6a82cbfbde2f.png">


## Troubleshooting:
Type `npm i` in Terminal within the `/frontend/floop_feedback/` folder then `npm start` if `npm start `doesn't work right away.
