### PR TITLE
Configure API gateway to invoke sentiment 

### DIFF
--- a/devops/makeAPIGateway/makeAPIGatewayInvokeSentiment.sh
+++ b/devops/makeAPIGateway/makeAPIGatewayInvokeSentiment.sh
@@ -1,0 +1,60 @@
+# !/bin/sh
+INITIALS_PROMPT="Please enter your first and last initial (or 'q' to quit)"
+NUM=2
+
+while :
+  do
+    # get and validate user initials
+    printf "%s\n" "$INITIALS_PROMPT" 
+    while read initials && [ "$initials" != "q" ];
+      do
+        # checks to see if string is null or has zero length
+        if [ -z "$initials" ]; then
+          printf '%s\n' "Error: initials can't be empty" 
+        # checks to see if the string matches the requested pattern
+        elif [[ "${initials}" =~ [^a-zA-Z] ]]; then
+          printf '%s\n' "Error: initials must only contain letters, a-z"
+        elif [[ "${#initials}" != $NUM ]]; then
+          printf '%s\n' "Error: initials must be $NUM characters"
+        else
+          break
+        fi
+          printf "%s\n" "$INITIALS_PROMPT" 
+      done
+
+    if [ "$initials" == "q" ]; then
+      printf '%s\n' "Done"
+      break
+    fi
+
+
+    # converts initials to lowercase and remove spaces
+    formattedInitials="$(echo "${initials}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    todayDate=$(date +'%Y%m%d')
+    OPENSSL_STRING=$(openssl rand -hex 3)
+    RANDOM_STRING=${OPENSSL_STRING:0:5}
+    uniqueName=$formattedInitials-$RANDOM_STRING-$todayDate
+    APIName=$uniqueName-api
+    stackName=$uniqueName-stack
+
+    printf "%s\n" "Your API and stack will be named as follows:" \
+            "api: $APIName" \
+            "stack: $stackName" \
+            "Create API? (y/n)" 
+
+    apiTemplate="./makeAPIGatewayInvokeSentiment.yml"
+    while read answer && [ "$answer" != "q" ];
+      do
+        if [ "$answer" == "y" ]; then
+          printf '%s\n' "aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName --parameter-overrrides APIName=$APIName"
+          aws cloudformation deploy --template-file $apiTemplate --stack-name $stackName --parameter-overrides APIName=$APIName
+          break
+        elif [ "$answer" == "n" ]; then
+          break
+        else
+          printf "%s\n" "Create API? (y/n)"
+        fi
+      done
+    printf '%s\n' "Done" 
+    break
+  done 

--- a/devops/makeAPIGateway/makeAPIGatewayInvokeSentiment.yml
+++ b/devops/makeAPIGateway/makeAPIGatewayInvokeSentiment.yml
@@ -1,0 +1,71 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: AWS API Gateway with a Lambda Integration to invoke sentiment sagemaker model
+Parameters:
+  APIName:
+    Description: Unique name of your API.
+    Type: String
+Resources:
+  ApiGatewayRestApi:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      ApiKeySourceType: HEADER
+      Description: >-
+        An API Gateway with a Lambda Integration to invoke sentiment sagemaker
+        model
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      Name: !Ref APIName
+  ProxyResource:
+    Type: 'AWS::ApiGateway::Resource'
+    Properties:
+      ParentId: !GetAtt ApiGatewayRestApi.RootResourceId
+      PathPart: sentiment
+      RestApiId: !Ref ApiGatewayRestApi
+  ProxyResourceANY:
+    Type: 'AWS::ApiGateway::Method'
+    Properties:
+      ApiKeyRequired: false
+      AuthorizationType: NONE
+      HttpMethod: POST
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS
+        Uri: !Sub >-
+          arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:061431082068:function:se_85400/invocations
+        IntegrationResponses:
+        - StatusCode: 200
+      MethodResponses:
+      - StatusCode: 200
+        ResponseModels:
+          application/json: Empty
+      OperationName: sentiment
+      ResourceId: !Ref ProxyResource
+      RestApiId: !Ref ApiGatewayRestApi
+  ApiGatewayModel:
+    Type: 'AWS::ApiGateway::Model'
+    Properties:
+      ContentType: application/json
+      RestApiId: !Ref ApiGatewayRestApi
+      Schema: {}
+  ApiGatewayStage:
+    Type: 'AWS::ApiGateway::Stage'
+    Properties:
+      DeploymentId: !Ref ApiGatewayDeployment
+      Description: API invoke sentiment v1
+      RestApiId: !Ref ApiGatewayRestApi
+      StageName: v1
+  ApiGatewayDeployment:
+    Type: 'AWS::ApiGateway::Deployment'
+    DependsOn: ProxyResourceANY
+    Properties:
+      Description: Lambda API Deployment
+      RestApiId: !Ref ApiGatewayRestApi
+  lambdaApiGatewayInvoke:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName: 'arn:aws:lambda:us-west-2:061431082068:function:se_85400'
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub >-
+        arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGatewayRestApi}/*/*/*


### PR DESCRIPTION
As a developer, I want to configure an API gateway that invokes a sagemaker model which determines the sentiment of a sentence so the user can easily see the sentiment behind teachers feedback

Closes #122 

## Testing Steps
**Prerequisite**
•	  Must have [AWS CLI](https://aws.amazon.com/cli/) set up with your credentials

**Creating the API Gateway that contains a Lambda API**
- [ ]	  Open a terminal window running bash
- [ ]	  Navigate to the makeAPIGateway folder
- [ ]	  Run ./makeAPIGatewayInvokeSentiment.sh
- [ ]	  Follow the prompts to enter your first and last initial (image 1)
- [ ]	  View the automatically generated names for the API Gateway and Lambda API
- [ ]	  Enter y to confirm creation of REST API and API Gateway, or enter n to exit the program
- [ ]	  If y is entered, an API Gateway containing Lambda REST API will be deployed
- [ ]	  After stack has been created, Navigate to the AWS console 
- [ ]	  Search API Gateway to view created APIs, and confirm newly created Lambda REST API is present (image 2)

**Testing in console**
- [ ] Navigate to the AWS console and search API Gateway to view created APIs, and confirm newly created Lambda REST API is present (image 2)
- [ ]    Select your created API and go to the resources tab in the left hand navigation. Your screen should look like image 3 after this step. Confirm that you see a /sentiment resource that contains a post method
- [ ]   Click on the post method under the /sentiment resource and click on "TEST" on the left hand side of the screen (image 4)
- [ ]  Confirm that your screen looks like image 5 and then type in {"sentence": "This is interesting class today"}
- [ ] click TEST at the bottom of the screen
- [ ]  Check the response body on the right. It should look something like image 6

**Testing in postman**
- [ ] Navigate and log in to postman
- [ ] Execute a post message using the url you can find in the post method in the v1 stage on the AWS console (image 7)
- [ ] Select body type raw and type in {"sentence": "This section is not clear enough"}. Hit send
- [ ] Your Response will be the same response as the one you got in the AWS console. (image 8)
## Images
1.	The script in the terminal
![image](https://user-images.githubusercontent.com/75229373/159200154-98eff8d9-bd9c-4275-a55d-eec634497544.png)


2.	The generated mock api and api gateway on AWS console
![image](https://user-images.githubusercontent.com/75229373/159200230-3391c12f-5b3f-4642-937d-614a8ccf8d77.png)

3. The view of the resources tab on the created API Gateway
![image](https://user-images.githubusercontent.com/75229373/159200366-922c6408-0061-49a7-ba75-ac82b6a2c03f.png)

4.
![image](https://user-images.githubusercontent.com/75229373/159200726-a5b637f5-a69a-4c72-89af-2d3b42c36b6e.png)

5.
![image](https://user-images.githubusercontent.com/75229373/159200992-dd4bd657-970d-47d5-810f-4dbc691cb2be.png)

6.
![image](https://user-images.githubusercontent.com/75229373/159201059-7364806a-dcdd-43cb-864a-a30e7d04ac61.png)

7. 
![image](https://user-images.githubusercontent.com/75229373/159199548-3990fe82-73ca-4cb6-898a-e71b79555bb2.png)
 
8.
![image](https://user-images.githubusercontent.com/75229373/159199581-95074119-29ea-40f3-a4a4-b15d2e7f4980.png)

## Known Issues
This API script uses a lambda created in issue #119. The lambda determines the sentiment of a sentence using python and is not running via sagemaker. See issue #119  for more details
This script is a shell script, and will not work if you are not using bash in your terminal. If you are using powershell, you can configure your computer to run bash on Windows.

