### PR TITLE
Improve the error handling of the teacher post api

### DIFF
--- a/backend/simpleLambdaForTeacherFeedback/index.js
+++ b/backend/simpleLambdaForTeacherFeedback/index.js
@@ -1,35 +1,47 @@
 exports.handler = async (event) => {
-  console.log("event: " + JSON.stringify(event));
-  console.log("----- lambda start");
-  let feedBack = "Good Job!";
-  // let Id = 1;
 
-  let responseCode = 201;
-  console.log("event: " + JSON.stringify(event));
-
-  if (event.body) {
-    let body = JSON.parse(event.body);
-    if (body.feedBack === "")
-      return {
-        statusCode: 400,
-      };
-    else feedBack = body.feedBack;
-    // if (body.Id)
-    // Id = body.id;
-  }
-
-  let FeedBack = `Teacher feed back:  ${feedBack}.`;
-
-  let responseBody = {
-    message: FeedBack,
-    // input: event
-  };
-
-  let response = {
-    statusCode: responseCode,
-
-    body: JSON.stringify(responseBody),
-  };
-
-  return response;
-};
+    let feedback = "";
+    let responseCode = 201;
+   
+   
+     if (event.body !== "") {
+       let body;
+       try {
+         body = JSON.parse(event.body);
+       } catch (e) {
+         body = { message: "dd" };
+       }
+   
+       if (event.feedback === "null" || event.feedback === "undefined")
+         return {
+           statusCode: "400",
+           body: JSON.stringify({ Error: " feed back undefined! or null!" }),
+         };
+       else if (body.feedback === "")
+         return {
+           statusCode: "400",
+           body: JSON.stringify({ Error: "Missing feedback string" }),
+         };
+       else if (!body.feedback)
+         return {
+           statusCode: "400",
+           body: JSON.stringify({ Error: "info not matched" }),
+         };
+       else feedback = body.feedback;
+      }
+    
+     let FeedBack = `Teacher feed back:  ${feedback}.`;
+   
+     let responseBody = {
+       message: FeedBack,
+       // input: event
+     };
+   
+     let response = {
+       statusCode: responseCode,
+   
+       body: JSON.stringify(responseBody),
+     };
+   
+     return response;
+   };


### PR DESCRIPTION
close #81 
### User Story 
Lambda accept teacher feedback ,and only return the feedback and successful invoke with 201.It event or feedback is not empty , or missing on syntax , it will return error message.

### To test it

Prerequisites
 Terminal 
Postmen  
Endpoint :  https://28o5v02966.execute-api.us-west-2.amazonaws.com/default/PostApiForTeacherFeedback

### Using postmen or smiler

1. Copy the endpoint and post it on the postmen url  

2. Change method from get to post
3. select body, raw ,and change text to JSON
4. sending json as {"feedback":"write something here "}
5. click send
6. getting response with 201 when it is succeed.
7. getting response 400 for empty string

### Using terminal

1.  curl -d '{"feedback":"Good job!"}' -H "Content-Type: application/json" -X POST  https://28o5v02966.execute-api.us-west-2.amazonaws.com/default/PostApiForTeacherFeedback
2. getting response with 201 when it is succeed
3. getting response 400 for empty string

###  Gallery
here some picture when feedback return  succeed or errors.

![Screen Shot 2022-02-28 at 6 39 47 PM](https://user-images.githubusercontent.com/56528434/156094368-ffe6d2c8-de42-4a42-b041-956961a1feef.png)

![Screen Shot 2022-02-28 at 6 39 18 PM](https://user-images.githubusercontent.com/56528434/156094388-5b17794d-855c-4cfe-9fda-290659dd1333.png)

![Screen Shot 2022-02-28 at 6 38 36 PM](https://user-images.githubusercontent.com/56528434/156094423-3136239c-b99c-4019-bc01-6ec01009f0df.png)

### Estimated time

![Screen Shot 2022-02-28 at 6 37 09 PM](https://user-images.githubusercontent.com/56528434/156094503-9c65332e-b143-439d-b2c3-037154668993.png)
