### PR TITLE
change classifier and add more for demo

### DIFF
--- a/frontend/documentation/MlModel.ipynb
+++ b/frontend/documentation/MlModel.ipynb
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 46,
    "id": "c842a13e-6eaf-4a2d-8e45-3b4a4be3e8af",
    "metadata": {},
    "outputs": [
@@ -855,7 +855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 49,
    "id": "6acc8870-78ed-4c6e-97ae-8c993c79bb05",
    "metadata": {
     "scrolled": true
@@ -894,8 +894,7 @@
    ],
    "source": [
     "from sklearn.linear_model import LogisticRegression\n",
-    "from sklearn.metrics import confusion_matrix\n",
-    "from sklearn.metrics import accuracy_score\n",
+    "from sklearn.metrics import confusion_matrix, classification_report, accuracy_score\n",
     "from sklearn.preprocessing import MinMaxScaler\n",
     "from sklearn.preprocessing import LabelEncoder\n",
     "\n",
@@ -936,7 +935,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "307d33c4",
+   "id": "b5f65226",
    "metadata": {},
    "source": [
     "|      | Predicted: bad feedback      | Predicted: good feedback |\n",
@@ -950,7 +949,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5545da32",
+   "id": "101cb808",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/frontend/documentation/MlModel.ipynb
+++ b/frontend/documentation/MlModel.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "ae3ee904",
    "metadata": {},
    "outputs": [],
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "0d7d36bf",
    "metadata": {},
    "outputs": [
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "6dc57f51",
    "metadata": {},
    "outputs": [
@@ -226,7 +226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "1eeee8bc",
    "metadata": {},
    "outputs": [
@@ -313,7 +313,7 @@
        "4             1         0         0          2"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "04473abc",
    "metadata": {
     "scrolled": true
@@ -422,7 +422,7 @@
        "4             1         0         0          2          False"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -434,7 +434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "cf4d106f",
    "metadata": {},
    "outputs": [
@@ -470,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "cec33eb4",
    "metadata": {},
    "outputs": [
@@ -556,7 +556,7 @@
        "good_feedback      0.824634 -0.046258  0.129271  -0.097538       1.000000"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -578,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "eae79c85",
    "metadata": {
     "scrolled": true
@@ -613,7 +613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
    "id": "ea08349d",
    "metadata": {},
    "outputs": [
@@ -640,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "d5d7a118",
    "metadata": {},
    "outputs": [
@@ -665,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "31a0110c",
    "metadata": {},
    "outputs": [
@@ -690,7 +690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "b5083be9",
    "metadata": {},
    "outputs": [
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "1d08b654",
    "metadata": {},
    "outputs": [
@@ -750,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "id": "a49c6a8e",
    "metadata": {},
    "outputs": [],
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 42,
    "id": "c842a13e-6eaf-4a2d-8e45-3b4a4be3e8af",
    "metadata": {},
    "outputs": [
@@ -786,11 +786,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "4501\n",
-      "10499\n",
+      "(10499, 4)\n",
+      "(4501, 4)\n",
       "--------------------------------------------------------------------\n",
-      "4501\n",
-      "10499\n"
+      "(4501,)\n",
+      "(10499,)\n"
      ]
     }
    ],
@@ -803,6 +803,7 @@
     "y_train = []\n",
     "count_good = 0\n",
     "count_bad = 0\n",
+    "\n",
     "\n",
     "# shuffle the data randomly\n",
     "teamp_list = df.values.tolist()\n",
@@ -833,11 +834,15 @@
     "            X_train.append(teamp_list[i][0:4])\n",
     "            y_train.append(teamp_list[i][4])\n",
     "\n",
-    "#print(len(X_test))\n",
-    "#print(len(X_train))\n",
-    "#print('--------------------------------------------------------------------')\n",
-    "#print(len(y_test))\n",
-    "#print(len(y_train))"
+    "X_test = pd.DataFrame(X_test, columns =['cover_length', 'question', 'keywords', 'sentiment'])\n",
+    "X_train = pd.DataFrame(X_train, columns =['cover_length', 'question', 'keywords', 'sentiment'])\n",
+    "y_test = pd.Series(y_test)\n",
+    "y_train = pd.Series(y_train)\n",
+    "print(X_train.shape)\n",
+    "print(X_test.shape)\n",
+    "print('--------------------------------------------------------------------')\n",
+    "print(y_test.shape)\n",
+    "print(y_train.shape)"
    ]
   },
   {
@@ -845,12 +850,12 @@
    "id": "b1e41bf6",
    "metadata": {},
    "source": [
-    "# Create linear regression classifier and check the accuracy of the model"
+    "# Create logistic regression classifier and check the accuracy of the model"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 45,
    "id": "6acc8870-78ed-4c6e-97ae-8c993c79bb05",
    "metadata": {
     "scrolled": true
@@ -860,23 +865,95 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.6004170908322115\n"
+      "Accuracy: 98.67%\n",
+      "[[4409    0]\n",
+      " [  60   32]]\n",
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       0.99      1.00      0.99      4409\n",
+      "           1       1.00      0.35      0.52        92\n",
+      "\n",
+      "    accuracy                           0.99      4501\n",
+      "   macro avg       0.99      0.67      0.75      4501\n",
+      "weighted avg       0.99      0.99      0.98      4501\n",
+      "\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXUAAAEWCAYAAACZnQc8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAjWUlEQVR4nO3dfZyVVb338c8XRKR8AhVEwKBCSz2JSehdWVgKqBV6SsVS0KzpIHay0tRT+XSOd1lp5V1amAqKD6HpERUVxGdTAQ1FQJTEdGAEtFLUAmbmd/9xrbEtDnvvgT2z91x8377Wa++9rqe1EX6z5netay1FBGZmlg9dqt0AMzOrHAd1M7MccVA3M8sRB3UzsxxxUDczyxEHdTOzHHFQt00mqYekWyW9JumGTTjPVyTNqGTbqkHSHZLGVbsdtnlyUN+MSPqypLmS3pDUkILPJytw6i8BfYAdIuLIjT1JRFwTESMq0J53kDRcUki6ab36vVP9fWWe5xxJU0rtFxGHRMTkjWyu2SZxUN9MSPoO8Avg/5IF4F2BS4DRFTj9+4BnI6KxAudqL6uAj0vaoaBuHPBspS6gjP9NWVX5L+BmQNJ2wHnAhIi4KSLejIh1EXFrRJyW9uku6ReSlqfyC0nd07bhkuolfVfSytTLPyFtOxc4Czg6/QZw4vo9WkkDU494i/T5eEnPS1otaamkrxTUP1Rw3MclzUlpnTmSPl6w7T5J/y3p4XSeGZJ2LPLHsBb4X2BMOr4rcBRwzXp/Vr+U9JKk1yU9LumAVD8K+K+C7/lkQTvOl/Qw8Bbw/lT3tbT9Ukk3Fpz/AkmzJKnc/39mbeGgvnn4P8BWwM1F9vk+sD8wBNgbGAb8oGD7zsB2QD/gRODXknpGxNlkvf/fR8TWEXF5sYZIei9wMXBIRGwDfByY18p+vYDb0747ABcBt6/X0/4ycALQG9gSOLXYtYGrgLHp/UhgAbB8vX3mkP0Z9AKuBW6QtFVE3Lne99y74JjjgDpgG+Av653vu8BH0g+sA8j+7MaF5+ewduKgvnnYAXilRHrkK8B5EbEyIlYB55IFqxbr0vZ1ETEdeAPYfSPb0wzsJalHRDRExIJW9jkMeC4iro6Ixoi4DngG+HzBPldGxLMR8Q9gKlkw3qCI+CPQS9LuZMH9qlb2mRIRr6ZrXgh0p/T3nBQRC9Ix69Y731vAsWQ/lKYA34yI+hLnM9toDuqbh1eBHVvSHxuwC+/sZf4l1b19jvV+KLwFbN3WhkTEm8DRwH8ADZJul/ShMtrT0qZ+BZ9f3oj2XA2cDBxIK7+5pBTTopTy+TvZbyfF0joALxXbGBGzgecBkf3wMWs3Duqbh0eAfwKHF9lnOdkNzxa78u7URLneBN5T8Hnnwo0RcVdEHAz0Jet9X1ZGe1ratGwj29TiauAkYHrqRb8tpUdOJ8u194yI7YHXyIIxwIZSJkVTKZImkPX4lwPf2+iWm5XBQX0zEBGvkd3M/LWkwyW9R1I3SYdI+kna7TrgB5J2SjcczyJLF2yMecCnJO2abtKe2bJBUh9JX0i59TVkaZymVs4xHdgtDcPcQtLRwB7AbRvZJgAiYinwabJ7COvbBmgkGymzhaSzgG0Ltq8ABrZlhIuk3YD/IUvBHAd8T9KQjWu9WWkO6puJiLgI+A7Zzc9VZCmDk8lGhEAWeOYCTwHzgSdS3cZcaybw+3Sux3lnIO5CdvNwOfBXsgB7UivneBX4XNr3VbIe7uci4pWNadN6534oIlr7LeQu4A6yYY5/IfvtpjC10vJg1auSnih1nZTumgJcEBFPRsRzZCNorm4ZWWRWafJNeDOz/HBP3cwsRxzUzcxyxEHdzCxHHNTNzHKk2MMoVbXuled9B9fepccuB1S7CVaDGtcu2+S5dNoSc7rt+P6anbunZoO6mVmHam7tcYnOx0HdzAwgmqvdgopwUDczA2h2UDczy41wT93MLEeaannhrvI5qJuZgW+UmpnlitMvZmY54hulZmb54RulZmZ54p66mVmONK0rvU8n4KBuZga+UWpmlitOv5iZ5Yh76mZmOeKeuplZfkRzPm6UeuUjMzPIeurlljJI6irpT5JuS597SZop6bn02rNg3zMlLZG0WNLIgvp9Jc1P2y6WVHJxDgd1MzPIcurllvJ8C1hU8PkMYFZEDAZmpc9I2gMYA+wJjAIukdQ1HXMpUAcMTmVUqYs6qJuZQTahV7mlBEn9gcOA3xVUjwYmp/eTgcML6q+PiDURsRRYAgyT1BfYNiIeiYgArio4ZoOcUzczg0qPfvkF8D1gm4K6PhHRABARDZJ6p/p+wKMF+9WnunXp/fr1RbmnbmYGbcqpS6qTNLeg1LWcRtLngJUR8XiZV24tTx5F6otyT93MDNq0SEZETAQmbmDzJ4AvSDoU2ArYVtIUYIWkvqmX3hdYmfavBwYUHN8fWJ7q+7dSX5R76mZmULHRLxFxZkT0j4iBZDdA74mIY4FpwLi02zjglvR+GjBGUndJg8huiM5OqZrVkvZPo17GFhyzQe6pm5kBEe2+8tGPgamSTgReBI7MrhsLJE0FFgKNwIT4V2PGA5OAHsAdqRSl7KZq7Vn3yvO12TCrqh67HFDtJlgNaly7rOT47VL+cd8VZcecHsO/usnXay/uqZuZged+MTPLFc/9YmaWI20Y/VLLHNTNzMDpFzOzXHH6xcwsRxzUzcxyxOkXM7Mc8Y1SM7MccfrFzCxHnH4xM8sR99TNzHLEQd3MLEdqdHLDtnJQNzMDaPToFzOz/PCNUjOzHMlJTt3L2ZmZQZZTL7cUIWkrSbMlPSlpgaRzU/05kpZJmpfKoQXHnClpiaTFkkYW1O8raX7adnFa1q4o99TNzKCSPfU1wGci4g1J3YCHJLUsQ/fziPhZ4c6S9iBby3RPYBfgbkm7pSXtLgXqgEeB6cAoSixp5566mRlUcuHpiIg30sduqRTr3o8Gro+INRGxFFgCDJPUF9g2Ih6JbN3Rq4DDS30NB3UzMyCamsoukuokzS0odYXnktRV0jxgJTAzIh5Lm06W9JSkKyT1THX9gJcKDq9Pdf3S+/Xri3JQNzODNvXUI2JiRAwtKBMLTxURTRExBOhP1uveiyyV8gFgCNAAXJh2by1PHkXqi3JQNzODbEhjuaXcU0b8HbgPGBURK1KwbwYuA4al3eqBAQWH9QeWp/r+rdQX5aBuZgbQHOWXIiTtJGn79L4HcBDwTMqRtzgCeDq9nwaMkdRd0iBgMDA7IhqA1ZL2T6NexgK3lPoaHv1iZgaVHP3SF5gsqStZx3lqRNwm6WpJQ8hSKC8A3wCIiAWSpgILgUZgQhr5AjAemAT0IBv1UnTkCziom5llmppK71OGiHgK2KeV+uOKHHM+cH4r9XOBvdpyfadf2klTUxNfOn4CJ5129gb3mb9oMR854DBm3PvgJl9v7dq1fPeHP+KQo77KMV8/hWUNKwBY/vIKjvrqN/niuAmM/so3+P3Nt2/ytaz6Ro4YzoKnH+CZhQ/xvdMmVLs5+VChIY3V5qDeTqbccAvvH7jrBrc3NTXx80uu5BPDPtqm8y5rWMHxJ3/vXfU33TaDbbfZmjumXsFxRx/ORZdcAcBOO/Riym8u5A+Tf811l/2Cy6dMZeWqV9v2ZaymdOnShYt/eT6f+/yx/NveB3L00Yfz4Q8PrnazOr8K5dSrzUG9Hby8chUP/HE2X/z8yA3uc+2N0zh4+Cfo1XP7d9Tfetc9jPnat/jiuAmc+5OLaSrzV8J7HnyE0YceBMCI4Qfw2OPziAi6devGlltuCcDadetozsn0opuzYR/bhz//+QWWLn2RdevWMXXqLXyhyN81K1M7jH6phnYL6pI+JOn0NF/BL9P7D7fX9WrJBb/8Ld856USk1v94V6x6hVkP/JGjDj/0HfV/fuFF7px1P1ennnWXLl24bca9ZV1z5apX2bn3jgBssUVXtn7ve/j7a68D0LBiFUeMHc9BR4zlxK8cSe+ddtiEb2fVtku/nXmp/l8j2+qXNbDLLjtXsUU5kZOeervcKJV0OnAMcD0wO1X3B66TdH1E/HgDx9WRzXPAJRf+D18be0x7NK9d3ffwY/TquT17fmgws594qtV9Lvjlb/n2+K/StWvXd9Q/NnceC59ZwpgTvwXAmjVr3u7J/+eZ57Fs+QrWNa6jYcUqvjguy6Mee9RojjhsBNFKD7xl7p++fXbi5qsuZeWqV/nPM8/j4AM/yY69er5rf+scWpvTqbX//9Y2UeO58nK11+iXE4E9I2JdYaWki4AFQKtBPT2VNRFg3SvPd8q/pX96aiH3PfQoDz4yhzVr1/Hmm29x+rk/4YKz/5UHX/DMc5x2dvZH8LfXXufBR+bQtWtXIoIvHHIQ3x5/wrvOe/GPzgKynPr3z7+QSb/6yTu29+m9Iy+vfIWde+9EY2MTb7z5Ftttu8079um90w58cND7eOLJpxlx4AGV/urWQZbVNzCg/y5vf+7fry8N6ca4bYIKjX6ptvZKvzSTzTa2vr5pW259e/wJzPrfKcz4w2R+eu4ZDNt373cEdIC7bpzEjD9MZsYfJjNi+Cf5wakT+OynPs7+Q4cw876HePVvfwfgtddXs/zl8v6xHvjJ/bll+t0AzLjvQfbbd28k8fLKVfxzzZq3z/en+QsZuGv/YqeyGjdn7jw++MFBDBw4gG7dunHUUaO59bYZ1W5W5+f0S1GnALMkPce/JqrZFfggcHI7XbOmtQwlPPqIwza4zwcGvY9vfn0sdad8n+ZoptsWW/D975zELjv3KXn+f//cSM78759yyFFfZbttt+Gn554BwPMvvMRPf3UZkogIjj/m39ntA4Mq86WsKpqamvjWKT9g+u3X0rVLFyZN/j0LFz5b7WZ1fjlJv6i9cnHK7hIOI5tVTGTzGMwpeFKqqM6afrH21WMXp43s3RrXLiu5eEQpb541puyY897zrt/k67WXdnuiNE1a82h7nd/MrKJqfKhiuTxNgJkZ1HyuvFwO6mZmQDTmY/SLg7qZGbinbmaWK86pm5nliHvqZmb5ETkJ6p6l0cwMoLGp/FKEpK0kzZb0pKQFks5N9b0kzZT0XHrtWXDMmZKWSFosaWRB/b6S5qdtF6u1iX/W46BuZgaVnCZgDfCZiNgbGAKMkrQ/cAYwKyIGA7PSZyTtAYwB9gRGAZekpfAALiWb5HBwKqNKXdxB3cwMKhbUI/NG+tgtlQBGA5NT/WTg8PR+NHB9RKyJiKXAEmBYWqh624h4JLJH/68qOGaDHNTNzMimLy63SKqTNLeg1BWeS1JXSfOAlcDMiHgM6BMRDelaDUDvtHs//jVHFmRTqvRLpb6V+qJ8o9TMDNo0+qVwmvANbG8ChkjaHrhZUrHFo1vLk0eR+qLcUzczg3aZejci/g7cR5YLX5FSKqTXlWm3emBAwWH9geWpvn8r9UU5qJuZAdHYXHYpRtJOqYeOpB7AQcAzwDRgXNptHHBLej8NGCOpu6RBZDdEZ6cUzWpJ+6dRL2MLjtkgp1/MzKCSy/f0BSanESxdgKkRcZukR4Cpkk4EXgSOBIiIBZKmAguBRmBCwRTl44FJQA/gjlSKclA3M6NyDx9FxFPAPq3Uvwp8dgPHnA+c30r9XKBYPv5dHNTNzMDTBJiZ5Uo+5vNyUDczg/zM/eKgbmYGRKODuplZfjj9YmaWHzlZI8NB3cwMcE/dzCxP3FM3M8uRaKx2CyrDQd3MDPfUzcxyxUHdzCxPouTyn52Cg7qZGe6pm5nlSjS7p25mlhvNTfkI6l75yMyMLP1SbilG0gBJ90paJGmBpG+l+nMkLZM0L5VDC445U9ISSYsljSyo31fS/LTt4rQCUlHuqZuZUdH0SyPw3Yh4QtI2wOOSZqZtP4+InxXuLGkPYAywJ7ALcLek3dLqR5cCdcCjwHSytU6Lrn7knrqZGRBRfil+nmiIiCfS+9XAIqBfkUNGA9dHxJqIWAosAYalxam3jYhHIiKAq4DDS30PB3UzM7KeermlXJIGki1t91iqOlnSU5KukNQz1fUDXio4rD7V9Uvv168vqmRQl3RBOXVmZp1Zc5PKLpLqJM0tKHXrn0/S1sAfgFMi4nWyVMoHgCFAA3Bhy66tNCeK1BdVTk/94FbqDinjODOzTqMtPfWImBgRQwvKxMJzSepGFtCviYibACJiRUQ0RUQzcBkwLO1eDwwoOLw/sDzV92+lvqgNBnVJ4yXNB3ZPvy60lKXAU6VObGbWmUSo7FJMGqFyObAoIi4qqO9bsNsRwNPp/TRgjKTukgYBg4HZEdEArJa0fzrnWOCWUt+j2OiXa8nusv4IOKOgfnVE/LXUic3MOpMKPlH6CeA4YL6keanuv4BjJA0hS6G8AHwDICIWSJoKLCQbOTMhjXwBGA9MAnqQxeOiI18AFKVu5QKSPgkMjogrJe0IbJPu0rabda88n48FA62ieuxyQLWbYDWoce2yTR6P+OyHR5Udc3ZbdGfNPqlUcpy6pLOBocDuwJXAlsAUsp9GZma5UCqt0lmU8/DREWRDclrGXS5PA+rNzHIjL9MElBPU10ZESAoASe9t5zaZmXW4zWlCr6mSfgtsL+nrwFfJhuOYmeVG8+aSfomIn0k6GHidLK9+VkTMLHGYmVmnsjnl1ElB3IHczHKrjIGAnUI5o19W8+5HU18D5pLNRPZ8ezTMzKwjbTbpF+AiskdTryWbi2AMsDOwGLgCGN5ejTMz6yjNOblRWs7cL6Mi4rcRsToiXk9zHBwaEb8HepY62MysM2gOlV1qWTk99WZJRwE3ps9fKtjWblmorft/ur1ObZ1Ybf9zss4sLzdKy+mpf4VsHoOVwIr0/lhJPYCT27FtZmYdZrPoqUvqCoyPiM9vYJeHKt8kM7OOl5PBL8WDekQ0Sdq3oxpjZlYtTc35WAiunJz6nyRNA24A3mypbJn43cwsDyo38251lRPUewGvAp8pqAvAQd3MciNychu+nGkCTuiIhpiZVVNzTpLq5Sw8vZWkCZIuSStgXyHpio5onJlZR2lGZZdiJA2QdK+kRZIWSPpWqu8laaak59Jrz4JjzpS0RNJiSSML6veVND9tuzgta1dUOXcGriZ7gnQkcD/Z4qeryzjOzKzTCFR2KaGRbAqVDwP7AxMk7UG2LOisiBgMzEqfSdvGAHsCo4BL0shDgEuBOrJ1Swen7UUVW3i6JTXzwYj4IfBmREwGDgP+rdSJzcw6kyZUdikmIhoiomVRodXAIqAfMBqYnHabDBye3o8Gro+INWmZ0CXAsLRQ9bYR8Uhk645eVXDMBhXrqc9Or+vS698l7QVsBwwsdWIzs86kuQ1FUp2kuQWlrrVzShpItnLcY0CfiGiALPADvdNu/YCXCg6rT3X90vv164sqZ/TLxJT7+QEwDdga+GEZx5mZdRptGdKY5sCaWGwfSVsDfwBOiYjXi6TDW9sQReqLKhbUe0v6TnrfMgLm1+nVS9qZWa5UckijpG5kAf2agmd6VkjqGxENKbWyMtXXAwMKDu9PNjNufXq/fn1RxdIvXcl65dsUlK0LiplZbjSr/FJMGqFyObAoIi4q2DQNGJfejwNuKagfI6m7pEFkN0RnpxTNakn7p3OOLThmg4r11Bsi4rxSJzAzy4NSQxXb4BNkEx/OlzQv1f0X8GOyNZ9PBF4EjgSIiAWSpgILyUbOTIiIpnTceGAS0AO4I5WiigX1fDxeZWZWhqbSu5QlIh5iw/Hzsxs45nzg/Fbq5wJ7teX6xYJ6qxc3M8uj5tLP9XQKGwzqEfHXjmyImVk15WSWgLKGNJqZ5d7mNEujmVnu5WTdaQd1MzOg5OP/nYWDupkZ7qmbmeWKc+pmZjni0S9mZjni9IuZWY44/WJmliNN7qmbmeWHe+pmZjnioG5mliMe/WJmliMe/WJmliN5Sb8UW87OzGyz0dSGUoqkKyStlPR0Qd05kpZJmpfKoQXbzpS0RNJiSSML6veVND9tu1hFVq9u4aBuZkbl1ihNJgGjWqn/eUQMSWU6gKQ9gDHAnumYSyR1TftfCtSRrVs6eAPnfAcHdTMzsvRLuaWUiHgAKHehodHA9RGxJiKWAkuAYZL6AttGxCMREcBVwOGlTuagbmZGNvql3CKpTtLcglJX5mVOlvRUSs/0THX9gJcK9qlPdf3S+/Xri3JQNzMDmomyS0RMjIihBWViGZe4FPgAMARoAC5M9a0ldKJIfVEe/WJmRnk3QDdFRKxoeS/pMuC29LEeGFCwa39gearv30p9Ue6pm5lR2Zx6a1KOvMURQMvImGnAGEndJQ0iuyE6OyIagNWS9k+jXsYCt5S6jnvqZmZU9uEjSdcBw4EdJdUDZwPDJQ0hS6G8AHwDICIWSJoKLAQagQkR0fKLw3iykTQ9gDtSKcpB3cyMLKdeKRFxTCvVlxfZ/3zg/Fbq5wJ7teXaDupmZnjuFzOzXMnLNAEO6mZmQFNO+uoO6mZmuKduZpYrlbxRWk0O6mZm+EapmVmuOP1iZpYjvlFqZpYjecmpe+6XGrTddtty3bW/4akn7+XJefew334fpWfP7Zl++zUsePoBpt9+Ddtvv121m2kdpHv37vzx4dt4fO5M5s27h7PO+i4AP/7RD5g//36eeHwmN9zwO7bbbtsqt7Rza8vUu7XMQb0GXXjhOcyYeR8f2ftAhn5sJM88s4TTTj2Je+59mD33+hT33Pswp516UrWbaR1kzZo1HDziKPYdejBDh45g5Ijh7Dfso9w96wGGDPkMH933YJ577nlOP/3kaje1U2vL1Lu1zEG9xmyzzdYc8Mn9uPLK6wFYt24dr732Op///AimTLkRgClTbuQLXxhZ7DSWM2+++RYA3bptQbdu3YgI7r77AZqasnmfHnvsCfr361vsFFZCe8/S2FEc1GvMoEG7smrVX7nssot47NE7uPTSn/Ce9/Sgd+8defnllQC8/PJKdtpphyq31DpSly5dmDtnBsuXPcXdsx5g9pw/vWP78ceP4c677q1S6/Ih2vBfLevwoC7phCLb3l4iqqnpjY5sVs3YYost2GefvZg48Sr22/8Q3nrzLU47bUK1m2VV1tzczNCPjWDgoKF8bOg+7Lnn7m9vO+OM/6SxsZFrr72pii3s/JqIskstq0ZP/dwNbShcIqpr1607sk01Y9myBuqXNTBnzjwAbrp5OvsM2YuVK19h5517A7Dzzr1ZterVKrbSquW1117n/gf+yIgRwwE47rgjOezQgxg71vn0TeX0SxFpYdXWynygT3tcMy9WrFhFfX0Duw1+PwAHHvgJFi16jttum8mxx34JgGOP/RK33jqjms20DrTjjr3eHtmy1VZb8dnPHMDixX9mxIjhnHrqSRzx78fzj3/8s8qt7PyaI8oupaSFpVdKerqgrpekmZKeS689C7adKWmJpMWSRhbU7ytpftp2cVoBqaj2GqfeBxgJ/G29egF/bKdr5sa3v/1DJk36f2y5ZTeWLn2Rr9d9ly5dxLXXXMoJx4/hpZeWccyXx1e7mdZB+vbtwxWX/4KuXbugLl248cZbmT79bhYtfIju3btz5x3ZTfXHHnuCCSefUeXWdl4VTqpMAn4FXFVQdwYwKyJ+LOmM9Pl0SXsAY4A9gV2AuyXtllY/uhSoAx4FpgOjKLH6kaKMnzptJely4MqIeKiVbddGxJdLnaP7VgNqO3FlVdHcXOu//Fo1rFu7bJMXo/vy+44oO+Zc+5ebS15P0kDgtojYK31eDAyPiIa0Xul9EbG7pDMBIuJHab+7gHPIlry7NyI+lOqPScd/o9h126WnHhEnFtlWMqCbmXW0toxqkVRH1oNuMTEiJpY4rE9aTJoU2Hun+n5kPfEW9aluXXq/fn1RnibAzAxobENQTwG8VBAvV2u9/ihSX5THqZuZ0SHj1FektAvpdWWqrwcGFOzXH1ie6vu3Ul+Ug7qZGR0ypHEaMC69HwfcUlA/RlJ3SYOAwcDslKpZLWn/NOplbMExG+T0i5kZUMlBI5KuA4YDO0qqB84GfgxMlXQi8CJwZLruAklTgYVAIzAhjXwBGE82kqYH2aiXoiNfoJ1Gv1SCR79Yazz6xVpTidEvo3f9XNkx55YXb9vk67UX99TNzPAiGWZmuVLrU+qWy0HdzIzK5tSryUHdzIzan6irXA7qZma07YnSWuagbmaGc+pmZrnSFPlIwDiom5nh9IuZWa6Us/hFZ+CgbmZGxRfJqBoHdTMzfKPUzCxXHNTNzHLEo1/MzHLEo1/MzHLEc7+YmeVIXnLqXs7OzIysp15uKUXSC5LmS5onaW6q6yVppqTn0mvPgv3PlLRE0mJJIzfleziom5kBTTSXXcp0YEQMiYih6fMZwKyIGAzMSp+RtAcwBtgTGAVcIqnrxn4PB3UzM7InSsstG2k0MDm9nwwcXlB/fUSsiYilwBJg2MZexEHdzIxs9Eu5/0mqkzS3oNS963QwQ9LjBdv6REQDQHrtner7AS8VHFuf6jaKb5SamdG2uV8iYiIwscgun4iI5ZJ6AzMlPVNk39YWsd7oXwfcUzczo2099ZLnilieXlcCN5OlU1ZI6guQXlem3euBAQWH9weWb+z3cFA3M6NyOXVJ75W0Tct7YATwNDANGJd2Gwfckt5PA8ZI6i5pEDAYmL2x38PpFzMzKjpNQB/gZkmQxdhrI+JOSXOAqZJOBF4EjgSIiAWSpgILgUZgQkQ0bezFVatPUXXfakBtNsyqqrk5H/NzWGWtW7ustbx0m7x/x33KjjnPv/KnTb5ee3FP3cwMCE/oZWaWH3mZJsBB3cwMT+hlZpYr7qmbmeVIU05uwjuom5nhRTLMzHLFOXUzsxxxTt3MLEfcUzczyxHfKDUzyxGnX8zMcsTpFzOzHNmEZepqioO6mRkep25mlivuqZuZ5UhzTqbe9XJ2ZmZkN0rLLaVIGiVpsaQlks7ogOa/zT11MzMqN/pFUlfg18DBZItKz5E0LSIWVuQCJbinbmYGRBtKCcOAJRHxfESsBa4HRrdLo1tRsz31Nf98qWbXAOxokuoiYmK122G1xX8vKquxDeucSqoD6gqqJhb8v+gHvFSwrR7Yb9NbWB731DuHutK72GbIfy+qJCImRsTQglL4w7W1Hw4dNrTGQd3MrLLqgQEFn/sDyzvq4g7qZmaVNQcYLGmQpC2BMcC0jrp4zebU7R2cN7XW+O9FDYqIRkknA3cBXYErImJBR11feZnExszMnH4xM8sVB3UzsxxxUK9x1Xzc2GqTpCskrZT0dLXbYrXHQb2GFTxufAiwB3CMpD2q2yqrAZOAUdVuhNUmB/XaVtXHja02RcQDwF+r3Q6rTQ7qta21x437VaktZtYJOKjXtqo+bmxmnY+Dem2r6uPGZtb5OKjXtqo+bmxmnY+Deg2LiEag5XHjRcDUjnzc2GqTpOuAR4DdJdVLOrHabbLa4WkCzMxyxD11M7MccVA3M8sRB3UzsxxxUDczyxEHdTOzHHFQt4qS1CRpnqSnJd0g6T2bcK5Jkr6U3v+u2GRmkoZL+njB5/+QNHZjr23WWTmoW6X9IyKGRMRewFrgPwo3ppkn2ywivhYRC4vsMhx4O6hHxG8i4qqNuZZZZ+agbu3pQeCDqRd9r6RrgfmSukr6qaQ5kp6S9A0AZX4laaGk24HeLSeSdJ+koen9KElPSHpS0ixJA8l+eHw7/ZZwgKRzJJ2a9h8i6dF0rZsl9Sw45wWSZkt6VtIBHfvHY1Z5Xnja2oWkLcjmgb8zVQ0D9oqIpZLqgNci4mOSugMPS5oB7APsDvwb0AdYCFyx3nl3Ai4DPpXO1Ssi/irpN8AbEfGztN9nCw67CvhmRNwv6TzgbOCUtG2LiBgm6dBUf1CF/yjMOpSDulVaD0nz0vsHgcvJ0iKzI2Jpqh8BfKQlXw5sBwwGPgVcFxFNwHJJ97Ry/v2BB1rOFRFF5xWXtB2wfUTcn6omAzcU7HJTen0cGFjWNzSrYQ7qVmn/iIghhRWSAN4srCLrOd+13n6HUnpqYZWxT1usSa9N+N+D5YBz6lYNdwHjJXUDkLSbpPcCDwBjUs69L3BgK8c+Anxa0qB0bK9UvxrYZv2dI+I14G8F+fLjgPvX388sL9wzsWr4HVmq4wll3fhVwOHAzcBngPnAs7QSfCNiVcrJ3ySpC7ASOBi4FbhR0mjgm+sdNg74TRpe+TxwQjt8J7Oa4FkazcxyxOkXM7MccVA3M8sRB3UzsxxxUDczyxEHdTOzHHFQNzPLEQd1M7Mc+f8WiiWhYlaJYwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.metrics import confusion_matrix\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "\n",
+    "\n",
+    "label_encoder = LabelEncoder()\n",
+    "scaler = MinMaxScaler()\n",
+    "scaler.fit(X_train)\n",
+    "scaler.fit(X_test)\n",
+    "X_train = scaler.transform(X_train)\n",
+    "X_test = scaler.transform(X_test)\n",
+    "y_train = label_encoder.fit_transform(y_train)\n",
+    "y_test = label_encoder.fit_transform(y_test)\n",
     "\n",
     "# create Linear Regression classifier\n",
-    "reg = LinearRegression()\n",
+    "reg = LogisticRegression()\n",
     "\n",
     "# fit the data in it\n",
     "reg.fit(X_train, y_train)\n",
+    "y_pred = reg.predict(X_test)\n",
     "\n",
-    "# print the accuracy of the model\n",
-    "# expected that will be low\n",
-    "print(reg.score(X_test, y_test))"
+    "# Computing the accuracy\n",
+    "accuracy = accuracy_score(y_test, y_pred)\n",
+    "print(\"Accuracy: {:.2f}%\".format(accuracy * 100))\n",
+    "\n",
+    "# show Confusion Matrix\n",
+    "# This classifier is unreliable because the imbalance classes data\n",
+    "\n",
+    "cf = confusion_matrix(y_test, y_pred)\n",
+    "plt.figure()\n",
+    "sns.heatmap(cf, annot=True)\n",
+    "plt.xlabel('Prediction')\n",
+    "plt.ylabel('Target')\n",
+    "plt.title('Confusion Matrix')\n",
+    "\n",
+    "print(confusion_matrix(y_test, y_pred))\n",
+    "print(classification_report(y_test, y_pred))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "307d33c4",
+   "metadata": {},
+   "source": [
+    "|      | Predicted: bad feedback      | Predicted: good feedback |\n",
+    "| ----------- | ----------- | ----------- |\n",
+    "| Actual:  bad feedback| True Positive | False Negative       |\n",
+    "| Actual:  good feedback | False Positive   | True Negative        |\n",
+    "\n",
+    "## Accuracy = (tp+tn) / (tp + tn + fp + fn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5545da32",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
# Documentation:

Closes #153

Change classifier to LogisticRegression
Add confusion matrix for demo the classifier.

User story, acceptance criteria will show on the [related issue](https://github.com/North-Seattle-College/ad440-winter2022-tuesday-repo/issues/153)

| Task Breakdown Description      | Approx. Time |
| ----------- | ----------- |
| Researching for LogisticRegression | 1 hour       |
| add more content to the note | 2 hours        |
| Frontend Team Meets | 1 hours        |

## How to deploy the functionality locally or in the cloud?
It can run locally after download the file.

## How to configure the functionality?
It needs to use Jupyter notebook, pandas, NumPy, nltk, matplotlib, sklearn, and seaborn python libraries.
Thus, you can run it after downloading them with [pip](https://pip.pypa.io/en/stable/).
Also, we use "floopData02-16-2022-21-06-37.json" as data, so go to AWS S3 dashboard and the file is in the bucket called floop-dataset.

## How to access the implemented functionality?

Open the file in Jupyter notebook, and run each grid.

## What input to provide?

The input will be floopData02-16-2022-21-06-37.json file.

## What output is expected?

The output will be DataFrames  and graphics of the floopData02-16-2022-21-06-37.json.
Also, the prediction and knn.score. 

## Initial estimated time
5 hours